### PR TITLE
Fix stuck DOF blur when exiting photomode

### DIFF
--- a/client/camera.lua
+++ b/client/camera.lua
@@ -7,6 +7,10 @@ function Cam.Create(name)
 end
 
 function Cam.Destroy(name)
+    -- FIX: Reset DOF parameters before destroying the camera to prevent permanent blur
+    SetCamUseShallowDofMode(Cam.Cache[name], false)
+    SetCamDofStrength(Cam.Cache[name], 0.0)
+    
     Cam.SetActive(name, false, false, 0)
     DestroyCam(Cam.Cache[name], false)
     Cam.Cache[name] = nil

--- a/client/client.lua
+++ b/client/client.lua
@@ -232,6 +232,9 @@ function PHOTOMODE.Start()
         -- Show HUD and radar
         DisplayHud(true)
         DisplayRadar(true)
+        -- Clears any lingering focus state on the player ped to stop infinite blur
+        ClearFocus()
+            
         Config.ExitedPhotomode()
     end)
 end

--- a/config.lua
+++ b/config.lua
@@ -36,15 +36,10 @@ function Config.ExitedPhotomode()
 
 end
 
+-- VIP CONFIGURATION
+-- VIP logic has been moved to server/main.lua for security
+-- You can configure the Discord role check framework at the very top of that file
 
--- Function Server Side
--- This function currently returns false for all players.
--- To implement VIP checks, you need to edit this function to include the logic for determining if a player is a VIP.
--- Replace the 'return false' line with the appropriate VIP check logic.
-function Config.IsPlayerVIP(source)
-    -- Add your VIP check logic here
-    return false
-end
 
 function Config.SendNotification(source, message)
     if Config.NotificationType == 'esx' then

--- a/server/main.lua
+++ b/server/main.lua
@@ -6,6 +6,62 @@ RegisterNetEvent("photomode:RemovePlayerInPhotomode", function()
     TriggerClientEvent("photomode:RemovePlayerInPhotomode", -1, source)
 end)
 
+-- SECURE SERVER-SIDE DISCORD VIP CONFIG
+local DiscordVIP = {
+    BotToken = "YOUR_BOT_TOKEN_HERE", -- Your Discord Bot Token
+    GuildID = "YOUR_GUILD_ID_HERE",   -- Your Discord Server ID
+    RoleID = "YOUR_ROLE_ID_HERE"      -- The ID of the VIP Role
+}
+
+-- Isolated server-side VIP check function
+local function IsPlayerVIP(source)
+    -- Checks if bot token is properly set up
+    if DiscordVIP.BotToken == "YOUR_BOT_TOKEN_HERE" or DiscordVIP.BotToken == "" then
+        print("^1[Photomode] ERROR: Config.CheckVIP is true, but Discord Bot Token is missing in main.lua!^0")
+        return false 
+    end
+
+    local discordId = nil
+    
+    -- Extract the player's Discord identifier from FiveM
+    for i = 0, GetNumPlayerIdentifiers(source) - 1 do
+        local id = GetPlayerIdentifier(source, i)
+        if string.find(id, "discord:") then
+            discordId = string.gsub(id, "discord:", "")
+            break
+        end
+    end
+
+    -- If the player doesn't have Discord linked, deny VIP
+    if not discordId then return false end
+
+    -- Create a promise to halt the script while we wait for Discord to reply
+    local p = promise.new()
+    local endpoint = ("https://discord.com/api/v10/guilds/%s/members/%s"):format(DiscordVIP.GuildID, discordId)
+    
+    PerformHttpRequest(endpoint, function(errorCode, resultData, resultHeaders)
+        if errorCode == 200 and resultData then
+            local data = json.decode(resultData)
+            if data and data.roles then
+                -- Check if the player has the matching Role ID
+                for _, role in ipairs(data.roles) do
+                    if role == DiscordVIP.RoleID then
+                        p:resolve(true)
+                        return
+                    end
+                end
+            end
+        end
+        p:resolve(false)
+    end, "GET", "", {
+        ["Authorization"] = "Bot " .. DiscordVIP.BotToken,
+        ["Content-Type"] = "application/json"
+    })
+
+    -- Await the result of the HTTP request before continuing
+    return Citizen.Await(p)
+end
+
 -- Server-side command logging with integrated permissions check
 RegisterCommand("photomode", function(source, args, rawCommand)
     if source == 0 then
@@ -44,7 +100,7 @@ RegisterCommand("photomode", function(source, args, rawCommand)
 
     -- VIP status check (if enabled in config)
     if Config.CheckVIP then
-        local isVIP = Config.IsPlayerVIP(source)
+        local isVIP = IsPlayerVIP(source) -- Now calling the clean local function
         if isVIP then
             hasPermission = true
         end
@@ -59,4 +115,4 @@ RegisterCommand("photomode", function(source, args, rawCommand)
         Config.SendNotification(source, Config.NoPermissionMessage)
     end
 
-end, false) -- false means that the command is not restricted via ACE by default
+end, false)


### PR DESCRIPTION
Hey, I initially opened this just to fix a camera bug, but since I kept pushing to the same branch, I went ahead and included a security/feature refactor for the VIP system as well. This PR now covers two main things:

1. Fixed permanent DOF blur when exiting
Players' screens were staying permanently blurred after closing the UI.
-In `camera.lua`, updated `Cam.Destroy` to explicitly set `SetCamUseShallowDofMode` to false and reset DOF strength to `0.0` before deleting the camera to stop the engine from inheriting the blur.
-In `client.lua`, added `ClearFocus()` at the end of the `PHOTOMODE.Start` thread as a failsafe so the engine completely drops ped focus when the UI closes.

2. Moved VIP logic server-side & added native Discord Role check
The previous VIP setup left a dummy function in the shared `config.lua` file. Since clients download that file, any tokens or queries placed there by anyones custom functions would be completely exposed.
-`config.lua`: Removed the exposed `Config.IsPlayerVIP` function entirely to close the security gap.
-`server/main.lua`: Created a secure `DiscordVIP` configuration block at the top so server owners have a safe, server-only place to drop their Bot Token, Guild ID, and Role ID. This could also be modified to anything they want, but Discord is typically used for these types of things so figure it would be nice to include.
-`server/main.lua`: Implemented a native, standalone Discord API check using `PerformHttpRequest` and promises, and pointed the `/photomode` command to use this secure local function.

Tested both locally on my server and everything runs smoothly.

Oh, also the version check is accurate in the newest version, it is saying to update from 1.0.5 to 1.0.3 in the server console.